### PR TITLE
Log INFO level by default, DEBUG if debug mode enabled

### DIFF
--- a/src/main/java/ortus/boxlang/modules/orm/ORMApp.java
+++ b/src/main/java/ortus/boxlang/modules/orm/ORMApp.java
@@ -218,7 +218,7 @@ public class ORMApp {
 	private void configureLoggingPerORMConfig() {
 		if ( this.config.logSQL ) {
 			LoggerContext loggerContext = runtime.getLoggingService().getLoggerContext();
-			loggerContext.getLogger( "org.hibernate.SQL" ).setLevel( logger.isDebugEnabled() ? Level.TRACE : Level.DEBUG );
+			loggerContext.getLogger( "org.hibernate.SQL" ).setLevel( logger.isDebugEnabled() ? Level.DEBUG : Level.INFO );
 			loggerContext.getLogger( "org.hibernate.type.descriptor.sql" ).setLevel( logger.isDebugEnabled() ? Level.TRACE : Level.DEBUG );
 		}
 	}


### PR DESCRIPTION
This fixes bx-orm from logging TRACE level logs if debug mode is enabled.

## Type of change

Please delete options that are not relevant.

- [x] Improvement