### PR TITLE
Patch/entity to query missing parent properties

### DIFF
--- a/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/AbstractEntityMeta.java
+++ b/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/AbstractEntityMeta.java
@@ -56,10 +56,13 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 	protected IStruct				parentMeta;
 
 	/**
-	 * All properties of the entity, including transient properties and parent properties.
+	 * All properties of the local entity, before filtering out non-persistent properties.
 	 */
-	protected Array					allProperties;
+	protected Array					localProperties;
 
+	/**
+	 * All persistent properties of the local entity and mapped super class (if any), after filtering out non-persistent properties.
+	 */
 	protected List<IPropertyMeta>	localPersistentProperties;
 
 	protected List<IPropertyMeta>	idProperties;
@@ -143,7 +146,7 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 
 		this.associations			= new ArrayList<>();
 		this.inheritedProperties	= new ArrayList<>();
-		this.allProperties			= new Array();
+		this.localProperties		= new Array();
 
 		// Parse extended entity metadata
 		this.parentMeta				= this.isExtended
@@ -157,7 +160,7 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 		}
 
 		// Only add the current entity's properties after first adding any parent properties.
-		this.allProperties.addAll( this.meta.getAsArray( Key.properties ) );
+		this.localProperties.addAll( this.meta.getAsArray( Key.properties ) );
 	}
 
 	private void addParentMeta( IStruct superMeta ) {
@@ -187,10 +190,8 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 			if ( superSuperMeta != null && !superSuperMeta.isEmpty() ) {
 				addParentMeta( superSuperMeta );
 			}
-			// now apppend our parent properties
-			this.allProperties.addAll( parentProperties );
-			// properties from MappedSuperClass parents should be included in certain entity serializations, entityToQuery(), etc.
-			this.inheritedProperties.addAll( inheritedPersistentProperties );
+			// For mappedSuperClass parents, we want to include their properties in the local entity's properties - not treat them as inherited properties.
+			this.localProperties.addAll( parentProperties );
 		} else if ( isParentPersistent
 		    && ( this.annotations.containsKey( ORMKeys.joinColumn ) || this.annotations.containsKey( ORMKeys.discriminatorValue ) ) ) {
 			this.isSubclass	= true;

--- a/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/AbstractEntityMeta.java
+++ b/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/AbstractEntityMeta.java
@@ -171,6 +171,7 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 		    // Default to true to support @mappedSuperClass without a value. Otherwise, mappedSuperClass=false will be parsed as boolean.
 		    && BooleanCaster.cast( parentAnnotations.getOrDefault( ORMKeys.mappedSuperClass, true ) );
 
+		Array	parentProperties			= superMeta.getAsArray( Key.properties );
 		if ( !isParentPersistent && isParentMappedSuperClass ) {
 			// recurse upwards first
 			IStruct superSuperMeta = superMeta.getAsStruct( Key._EXTENDS );
@@ -178,13 +179,14 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 				addParentMeta( superSuperMeta );
 			}
 			// now apppend our parent properties
-			this.allProperties.addAll( superMeta.getAsArray( Key.properties ) );
+			this.allProperties.addAll( parentProperties );
 		} else if ( isParentPersistent
 		    && ( this.annotations.containsKey( ORMKeys.joinColumn ) || this.annotations.containsKey( ORMKeys.discriminatorValue ) ) ) {
-			this.isSubclass	= true;
-			this.joinColumn	= this.annotations.getAsString( ORMKeys.joinColumn );
+			this.isSubclass = true;
+			this.allProperties.addAll( parentProperties );
+			this.joinColumn = this.annotations.getAsString( ORMKeys.joinColumn );
 			if ( this.joinColumn == null ) {
-				IStruct idColumn = superMeta.getAsArray( Key.properties )
+				IStruct idColumn = parentProperties
 				    .stream()
 				    .map( StructCaster::cast )
 				    .filter( item -> item.containsKey( Key.annotations ) )
@@ -417,7 +419,7 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 	}
 
 	/**
-	 * Gets ALL entity properties, including id,version,timestamp,relationship, and regular properties.
+	 * Gets ALL entity properties, including id,version,timestamp,relationship, and regular properties on all entities within the inheritance chain.
 	 *
 	 * @return all ORM properties.
 	 */

--- a/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/AbstractEntityMeta.java
+++ b/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/AbstractEntityMeta.java
@@ -60,9 +60,7 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 	 */
 	protected Array					allProperties;
 
-	protected List<IPropertyMeta>	allPersistentProperties;
-
-	protected List<IPropertyMeta>	parentPersistentProperties;
+	protected List<IPropertyMeta>	localPersistentProperties;
 
 	protected List<IPropertyMeta>	idProperties;
 
@@ -71,6 +69,8 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 	protected List<IPropertyMeta>	associations;
 
 	protected IPropertyMeta			versionProperty;
+
+	protected List<IPropertyMeta>	inheritedProperties;
 
 	protected String				datasource;
 
@@ -142,6 +142,7 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 		    && BooleanCaster.cast( this.annotations.getOrDefault( ORMKeys.selectBeforeUpdate, false ) );
 
 		this.associations			= new ArrayList<>();
+		this.inheritedProperties	= new ArrayList<>();
 		this.allProperties			= new Array();
 
 		// Parse extended entity metadata
@@ -160,18 +161,26 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 	}
 
 	private void addParentMeta( IStruct superMeta ) {
-		IStruct	parentAnnotations			= superMeta.getAsStruct( Key.annotations );
+		IStruct						parentAnnotations				= superMeta.getAsStruct( Key.annotations );
 		// @Entity
-		boolean	isParentPersistent			= parentAnnotations.containsKey( ORMKeys.entity )
+		boolean						isParentPersistent				= parentAnnotations.containsKey( ORMKeys.entity )
 		    // persistent="false"
 		    || ( parentAnnotations.containsKey( ORMKeys.persistent )
 		        && BooleanCaster.cast( parentAnnotations.getOrDefault( ORMKeys.persistent, false ) ) );
 		// @mappedSuperClass
-		boolean	isParentMappedSuperClass	= parentAnnotations.containsKey( ORMKeys.mappedSuperClass )
+		boolean						isParentMappedSuperClass		= parentAnnotations.containsKey( ORMKeys.mappedSuperClass )
 		    // Default to true to support @mappedSuperClass without a value. Otherwise, mappedSuperClass=false will be parsed as boolean.
 		    && BooleanCaster.cast( parentAnnotations.getOrDefault( ORMKeys.mappedSuperClass, true ) );
 
-		Array	parentProperties			= superMeta.getAsArray( Key.properties );
+		Array						parentProperties				= superMeta.getAsArray( Key.properties );
+
+		// properties from MappedSuperClass parents should be included in certain entity serializations, entityToQuery(), etc.
+		List<ClassicPropertyMeta>	inheritedPersistentProperties	= parentProperties
+		    .stream()
+		    .map( prop -> new ClassicPropertyMeta( this.getEntityName(), ( IStruct ) prop, this ) )
+		    // exclude properties explicitly marked as persistent="false"
+		    .filter( prop -> BooleanCaster.cast( prop.getAnnotations().getOrDefault( ORMKeys.persistent, true ) ) )
+		    .toList();
 		if ( !isParentPersistent && isParentMappedSuperClass ) {
 			// recurse upwards first
 			IStruct superSuperMeta = superMeta.getAsStruct( Key._EXTENDS );
@@ -180,11 +189,14 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 			}
 			// now apppend our parent properties
 			this.allProperties.addAll( parentProperties );
+			// properties from MappedSuperClass parents should be included in certain entity serializations, entityToQuery(), etc.
+			this.inheritedProperties.addAll( inheritedPersistentProperties );
 		} else if ( isParentPersistent
 		    && ( this.annotations.containsKey( ORMKeys.joinColumn ) || this.annotations.containsKey( ORMKeys.discriminatorValue ) ) ) {
-			this.isSubclass = true;
-			this.allProperties.addAll( parentProperties );
-			this.joinColumn = this.annotations.getAsString( ORMKeys.joinColumn );
+			this.isSubclass	= true;
+			this.joinColumn	= this.annotations.getAsString( ORMKeys.joinColumn );
+			// properties from persistent parents should be included in certain entity serializations, entityToQuery(), etc.
+			this.inheritedProperties.addAll( inheritedPersistentProperties );
 			if ( this.joinColumn == null ) {
 				IStruct idColumn = parentProperties
 				    .stream()
@@ -424,7 +436,19 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 	 * @return all ORM properties.
 	 */
 	public List<IPropertyMeta> getAllPersistentProperties() {
-		return this.allPersistentProperties;
+		List<IPropertyMeta> allProperties = new ArrayList<>( this.localPersistentProperties );
+		allProperties.addAll( this.inheritedProperties );
+		return allProperties;
+	}
+
+	/**
+	 * Gets entity properties, including id,version,timestamp,relationship, and regular properties on local entity only, excluding any parent (inherited)
+	 * properties.
+	 *
+	 * @return ORM properties for the local entity.
+	 */
+	public List<IPropertyMeta> getLocalPersistentProperties() {
+		return this.localPersistentProperties;
 	}
 
 	/**
@@ -455,21 +479,21 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 	}
 
 	/**
+	 * Gets properties from parent entities.
+	 * 
+	 * @return a List of IPropertyMeta containing the properties from parent entities.
+	 */
+	public List<IPropertyMeta> getInheritedProperties() {
+		return this.inheritedProperties;
+	}
+
+	/**
 	 * Gets all persistent property names as an Array of Keys for comparison
 	 *
 	 * @return An Array containing keys of the names of all persistent properties.
 	 */
 	public Array getPropertyNamesArray() {
-		Array	properties	= getAllPersistentProperties().stream().map( property -> KeyCaster.cast( property.getName() ) )
+		return getAllPersistentProperties().stream().map( property -> KeyCaster.cast( property.getName() ) )
 		    .collect( BLCollector.toArray() );
-
-		Array	parentMeta	= getParentMeta().getAsArray( Key.properties );
-		if ( parentMeta != null ) {
-			properties.addAll(
-			    parentMeta.stream().map( StructCaster::cast )
-			        .map( prop -> KeyCaster.cast( prop.getAsStruct( Key.annotations ).get( Key._NAME ) ) ).collect( BLCollector.toArray() )
-			);
-		}
-		return properties;
 	}
 }

--- a/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/AbstractEntityMeta.java
+++ b/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/AbstractEntityMeta.java
@@ -443,8 +443,8 @@ public abstract class AbstractEntityMeta implements IEntityMeta {
 	}
 
 	/**
-	 * Gets entity properties, including id,version,timestamp,relationship, and regular properties on local entity only, excluding any parent (inherited)
-	 * properties.
+	 * Gets persistent ORM properties that are mapped on this entity (the current table), including any @mappedSuperClass ancestors,
+	 * but excluding properties that belong to a persistent parent entity in a joined/discriminator inheritance hierarchy.
 	 *
 	 * @return ORM properties for the local entity.
 	 */

--- a/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/ClassicEntityMeta.java
+++ b/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/ClassicEntityMeta.java
@@ -76,7 +76,7 @@ public class ClassicEntityMeta extends AbstractEntityMeta {
 			this.cache.computeIfAbsent( ORMKeys.include, key -> this.annotations.getAsString( ORMKeys.cacheInclude ) );
 		}
 
-		this.localPersistentProperties	= this.allProperties.stream()
+		this.localPersistentProperties	= this.localProperties.stream()
 		    .map( IStruct.class::cast )
 		    .filter( ( IStruct prop ) -> {
 											    var annotations = prop.getAsStruct( Key.annotations );

--- a/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/ClassicEntityMeta.java
+++ b/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/ClassicEntityMeta.java
@@ -76,7 +76,7 @@ public class ClassicEntityMeta extends AbstractEntityMeta {
 			this.cache.computeIfAbsent( ORMKeys.include, key -> this.annotations.getAsString( ORMKeys.cacheInclude ) );
 		}
 
-		this.allPersistentProperties	= this.allProperties.stream()
+		this.localPersistentProperties	= this.allProperties.stream()
 		    .map( IStruct.class::cast )
 		    .filter( ( IStruct prop ) -> {
 											    var annotations = prop.getAsStruct( Key.annotations );
@@ -87,12 +87,12 @@ public class ClassicEntityMeta extends AbstractEntityMeta {
 		    .map( prop -> new ClassicPropertyMeta( this.getEntityName(), prop, this ) )
 		    .collect( Collectors.toList() );
 
-		this.idProperties				= this.allPersistentProperties.stream()
+		this.idProperties				= this.localPersistentProperties.stream()
 		    .filter( ( IPropertyMeta prop ) -> prop.getFieldType() == IPropertyMeta.FIELDTYPE.ID )
 		    .collect( Collectors.toList() );
 
 		if ( !this.isSubclass && this.idProperties.size() == 0 ) {
-			this.idProperties = this.allPersistentProperties.stream()
+			this.idProperties = this.localPersistentProperties.stream()
 			    .filter( ( IPropertyMeta prop ) -> prop.getName().equalsIgnoreCase( "id" ) )
 			    .collect( Collectors.toList() );
 
@@ -106,14 +106,14 @@ public class ClassicEntityMeta extends AbstractEntityMeta {
 			this.idProperties.forEach( ( IPropertyMeta prop ) -> prop.setFieldType( IPropertyMeta.FIELDTYPE.ID ) );
 		}
 
-		this.properties			= this.allPersistentProperties.stream().filter( (
+		this.properties			= this.localPersistentProperties.stream().filter( (
 		    IPropertyMeta prop ) -> prop.getFieldType() == IPropertyMeta.FIELDTYPE.COLUMN ).collect( Collectors.toList() );
 
-		this.versionProperty	= this.allPersistentProperties.stream().filter( (
+		this.versionProperty	= this.localPersistentProperties.stream().filter( (
 		    IPropertyMeta prop ) -> prop.getFieldType() == IPropertyMeta.FIELDTYPE.VERSION || prop.getFieldType() == IPropertyMeta.FIELDTYPE.TIMESTAMP )
 		    .findFirst().orElse( null );
 
-		this.associations		= this.allPersistentProperties.stream().filter( (
+		this.associations		= this.localPersistentProperties.stream().filter( (
 		    IPropertyMeta prop ) -> prop.isAssociationType() ).collect( Collectors.toList() );
 	}
 }

--- a/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/IEntityMeta.java
+++ b/src/main/java/ortus/boxlang/modules/orm/mapping/inspectors/IEntityMeta.java
@@ -136,9 +136,17 @@ public interface IEntityMeta {
 	/**
 	 * Property methods
 	 */
+	/**
+	 * Gets entity properties, including id,version,timestamp,relationship, and regular properties on local entity only, excluding any parent (inherited)
+	 * properties.
+	 *
+	 * @return ORM properties for the local entity.
+	 */
+	public List<IPropertyMeta> getLocalPersistentProperties();
 
 	/**
-	 * Retrieve a list of all persistent (ORM) properties
+	 * Retrieve a list of persistent (ORM) properties from all entities in the inheritance hierarchy, including parent entities, but excluding any
+	 * transient or non-persistent regular properties.
 	 *
 	 * Includes:
 	 * <ul>
@@ -150,6 +158,13 @@ public interface IEntityMeta {
 	 * </ul>
 	 */
 	public List<IPropertyMeta> getAllPersistentProperties();
+
+	/**
+	 * Gets persistent properties from parent entities.
+	 * 
+	 * @return a List of IPropertyMeta containing the properties from parent entities.
+	 */
+	public List<IPropertyMeta> getInheritedProperties();
 
 	/**
 	 * Retrieve a list of all key properties.

--- a/src/test/java/ortus/boxlang/modules/orm/bifs/EntityToQueryTest.java
+++ b/src/test/java/ortus/boxlang/modules/orm/bifs/EntityToQueryTest.java
@@ -98,6 +98,43 @@ public class EntityToQueryTest extends BaseORMTest {
 		assertThat( row.get( "manufacturer" ) ).isNull();
 	}
 
+	@DisplayName( "It includes properties from a parent entity in the query columns" )
+	@Test
+	public void testEntityToQueryIncludesParentProperties() {
+		// @formatter:off
+		instance.executeSource( """
+			result = entityToQuery(
+				entityLoadByPK( 'cbPage', '779cd2de-a444-11eb-ab6f-0290cc502ae3' )
+			);
+		""", context );
+		// @formatter:on
+
+		assertThat( variables.get( result ) ).isNotNull();
+		assertThat( variables.get( result ) ).isInstanceOf( Query.class );
+		assertThat( variables.getAsQuery( result ).size() ).isEqualTo( 1 );
+
+		IStruct row = variables.getAsQuery( result ).getRowAsStruct( 0 );
+
+		// child entity properties should be present
+		assertThat( row.containsKey( "layout" ) ).isTrue();
+		assertThat( row.containsKey( "order" ) ).isTrue();
+		assertThat( row.containsKey( "showInMenu" ) ).isTrue();
+		assertThat( row.containsKey( "excerpt" ) ).isTrue();
+
+		// parent (BaseContent) properties should also be present
+		assertThat( row.containsKey( "contentID" ) ).isTrue();
+		assertThat( row.containsKey( "title" ) ).isTrue();
+		assertThat( row.containsKey( "slug" ) ).isTrue();
+		assertThat( row.containsKey( "createdDate" ) ).isTrue();
+		assertThat( row.containsKey( "isPublished" ) ).isTrue();
+
+		// verify actual values from seed data
+		assertThat( row.get( "contentID" ) ).isEqualTo( "779cd2de-a444-11eb-ab6f-0290cc502ae3" );
+		assertThat( row.get( "title" ) ).isEqualTo( "support" );
+		assertThat( row.get( "slug" ) ).isEqualTo( "support" );
+		assertThat( row.get( "layout" ) ).isEqualTo( "pages" );
+	}
+
 	@DisplayName( "It can convert an empty array into a query" )
 	@Test
 	public void testEntityToQueryEmptyArray() {


### PR DESCRIPTION
# Description

Refactor ORM entity scan to include inherited `persistent` properties in the `getAllPersistentProperties()` method return value, while NOT including them in the generated entity mapping (`*.hbm.xml)`.

## Jira/Github Issues

https://ortussolutions.atlassian.net/browse/BL-2612

## Type of change

- [z] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
